### PR TITLE
Prevent installation of raspi-firmware package

### DIFF
--- a/overlays/raspberrypi4-uefi-bookworm/etc/apt/preferences.d/raspi-firmware.pref
+++ b/overlays/raspberrypi4-uefi-bookworm/etc/apt/preferences.d/raspi-firmware.pref
@@ -1,0 +1,4 @@
+# Block installation of raspi-firmware as it's only for non-UEFI boards.
+Package: raspi-firmware
+Pin: release o=Debian
+Pin-Priority: -1

--- a/raspberrypi4-uefi-bookworm.yaml
+++ b/raspberrypi4-uefi-bookworm.yaml
@@ -122,7 +122,6 @@ actions:
   - action: apt
     description: Install Raspberry Pi non-free firmware
     packages:
-      - raspi-firmware
       - firmware-brcm80211
       - firmware-misc-nonfree
       - bluez-firmware


### PR DESCRIPTION
The raspi-firmware package is only meant for non-UEFI boards.  We don't need it and it actively works against us if installed as we do not have a partition mounted at /boot/firmware.