### PR TITLE
raspi4,x86_64: Add security & updates apt repos

### DIFF
--- a/raspberrypi4-uefi-bookworm.yaml
+++ b/raspberrypi4-uefi-bookworm.yaml
@@ -23,6 +23,16 @@ actions:
       - non-free-firmware
     mirror: {{ $mirror }}
 
+  - action: run
+    description: Add security apt repo
+    chroot: true
+    command: echo deb http://deb.debian.org/debian-security/ bookworm-security main contrib non-free non-free-firmware >> /etc/apt/sources.list
+
+  - action: run
+    description: Add updates apt repo
+    chroot: true
+    command: echo deb {{ $mirror }} bookworm-updates main contrib non-free non-free-firmware >> /etc/apt/sources.list
+
   - action: apt
     description: Install expected base packages
     packages:

--- a/x86_64-uefi-bookworm.yaml
+++ b/x86_64-uefi-bookworm.yaml
@@ -18,6 +18,16 @@ actions:
       - non-free-firmware
     mirror: {{ $mirror }}
 
+  - action: run
+    description: Add security apt repo
+    chroot: true
+    command: echo deb http://deb.debian.org/debian-security/ bookworm-security main contrib non-free non-free-firmware >> /etc/apt/sources.list
+
+  - action: run
+    description: Add updates apt repo
+    chroot: true
+    command: echo deb {{ $mirror }} bookworm-updates main contrib non-free non-free-firmware >> /etc/apt/sources.list
+
   - action: apt
     description: Install expected base packages
     packages:


### PR DESCRIPTION
To ensure the most up-to-date packages are installed at debos-time.

Fixes: https://github.com/bradfa/debos-configs/issues/6